### PR TITLE
Authentication support on the registry

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = tornado_crud
+source = tornadowebapi
 omit = tests 
 
 [report]

--- a/tornadowebapi/__init__.py
+++ b/tornadowebapi/__init__.py
@@ -13,9 +13,9 @@ if not IS_RELEASED:
 
 
 def api_handlers(base_urlpath, version="v1"):
-    """Returns the API handlers for the REST interface.
-    Add these handlers to your application to provide a
-    REST interface to your Resources.
+    """Returns the API handlers for the interface.
+    Add these handlers to your application to provide an
+    interface to your Resources.
 
 
     Parameters

--- a/tornadowebapi/authenticator.py
+++ b/tornadowebapi/authenticator.py
@@ -1,0 +1,27 @@
+from tornado import gen
+
+
+class Authenticator:
+    @classmethod
+    @gen.coroutine
+    def authenticate(cls, handler):
+        """Performs authentication of the access"""
+        raise NotImplementedError("Missing implementation for authenticate")
+
+
+class NullAuthenticator(Authenticator):
+    """Authenticator class for the web handlers that does nothing and
+    returns None"""
+
+    @classmethod
+    @gen.coroutine
+    def authenticate(cls, handler):
+        """Called by the handler to authenticate the user.
+        The handler passes itself as an argument, and expects a valid
+        handler.current_user value, or None.
+
+        Note that returning None does not mean that the API will reject
+        the request. Just that the current_user is unrecognized.
+        Individual Resources must then adapt their behavior according to
+        this information"""
+        return None

--- a/tornadowebapi/handler.py
+++ b/tornadowebapi/handler.py
@@ -12,8 +12,8 @@ class BaseHandler(web.RequestHandler):
     @gen.coroutine
     def prepare(self):
         """Runs before any specific handler. """
-        # FIXME : Needs implementation to retrieve user.
-        self.current_user = None
+        authenticator = self.registry.authenticator
+        self.current_user = yield authenticator.authenticate(self)
 
     @property
     def registry(self):
@@ -79,7 +79,6 @@ class BaseHandler(web.RequestHandler):
 class CollectionHandler(BaseHandler):
     """Handler for URLs addressing a collection.
     """
-    @web.authenticated
     @gen.coroutine
     def get(self, collection_name):
         """Returns the collection of available items"""
@@ -103,7 +102,6 @@ class CollectionHandler(BaseHandler):
         self.write({"items": list(items)})
         self.flush()
 
-    @web.authenticated
     @gen.coroutine
     def post(self, collection_name):
         """Creates a new resource in the collection."""
@@ -146,7 +144,6 @@ class ResourceHandler(BaseHandler):
     """
     SUPPORTED_METHODS = ("GET", "POST", "PUT", "DELETE")
 
-    @web.authenticated
     @gen.coroutine
     def get(self, collection_name, identifier):
         """Retrieves the resource representation."""
@@ -169,7 +166,6 @@ class ResourceHandler(BaseHandler):
         self.write(representation)
         self.flush()
 
-    @web.authenticated
     @gen.coroutine
     def post(self, collection_name, identifier):
         """This operation is not possible in REST, and results
@@ -195,7 +191,6 @@ class ResourceHandler(BaseHandler):
         else:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 
-    @web.authenticated
     @gen.coroutine
     def put(self, collection_name, identifier):
         """Replaces the resource with a new representation."""
@@ -222,7 +217,6 @@ class ResourceHandler(BaseHandler):
         self.clear_header('Content-Type')
         self.set_status(httpstatus.NO_CONTENT)
 
-    @web.authenticated
     @gen.coroutine
     def delete(self, collection_name, identifier):
         """Deletes the resource."""

--- a/tornadowebapi/registry.py
+++ b/tornadowebapi/registry.py
@@ -1,9 +1,19 @@
 from .resource import Resource
+from .authenticator import NullAuthenticator
 
 
 class Registry:
     def __init__(self):
         self._registered_types = {}
+        self._authenticator = NullAuthenticator
+
+    @property
+    def authenticator(self):
+        return self._authenticator
+
+    @authenticator.setter
+    def authenticator(self, authenticator):
+        self._authenticator = authenticator
 
     def register(self, typ, collection_name=None):
         """Registers a Resource type with an appropriate

--- a/tornadowebapi/tests/test_registry.py
+++ b/tornadowebapi/tests/test_registry.py
@@ -37,3 +37,8 @@ class TestRegistry(unittest.TestCase):
         self.assertEqual(reg["students"], Student)
         self.assertEqual(reg["sheep"], Sheep)
         self.assertEqual(reg["octopuses"], Octopus)
+
+    def test_authenticator(self):
+        reg = Registry()
+
+        self.assertIsNotNone(reg.authenticator)


### PR DESCRIPTION
Allows authentication to be injected, with the default being no authentication.
Note that authentication is not authorization. Authentication recognizes the user. Authorization recognizes what it can do. We don't support authorization yet.
