### PR TITLE
Revert "Bad Representation exception"

### DIFF
--- a/tornadowebapi/exceptions.py
+++ b/tornadowebapi/exceptions.py
@@ -44,17 +44,13 @@ class NotFound(WebAPIException):
         return None
 
 
-class BadRepresentation(WebAPIException):
+class BadRequest(WebAPIException):
     """Exception raised when the resource representation is
     invalid or does not contain the appropriate keys.
     Raise this exception in your handlers when the received
     representation is ill-formed
     """
     http_code = httpstatus.BAD_REQUEST
-
-
-# Deprecated. Kept for compatibility
-BadRequest = BadRepresentation
 
 
 class Unable(WebAPIException):

--- a/tornadowebapi/tests/test_webapi.py
+++ b/tornadowebapi/tests/test_webapi.py
@@ -74,19 +74,19 @@ class UnsupportAll(Resource):
 class Unprocessable(Resource):
     @gen.coroutine
     def create(self, representation):
-        raise exceptions.BadRepresentation("unprocessable", foo="bar")
+        raise exceptions.BadRequest("unprocessable", foo="bar")
 
     @gen.coroutine
     def update(self, identifier, representation):
-        raise exceptions.BadRepresentation("unprocessable", foo="bar")
+        raise exceptions.BadRequest("unprocessable", foo="bar")
 
     @gen.coroutine
     def retrieve(self, identifier):
-        raise exceptions.BadRepresentation("unprocessable", foo="bar")
+        raise exceptions.BadRequest("unprocessable", foo="bar")
 
     @gen.coroutine
     def items(self):
-        raise exceptions.BadRepresentation("unprocessable", foo="bar")
+        raise exceptions.BadRequest("unprocessable", foo="bar")
 
 
 class UnsupportsCollection(Resource):
@@ -328,7 +328,7 @@ class TestREST(AsyncHTTPTestCase):
         self.assertEqual(res.code, httpstatus.BAD_REQUEST)
         self.assertEqual(res.headers["Content-Type"], 'application/json')
         self.assertEqual(escape.json_decode(res.body), {
-            "type": "BadRepresentation",
+            "type": "BadRequest",
             "message": "unprocessable",
             "foo": "bar",
         })
@@ -340,7 +340,7 @@ class TestREST(AsyncHTTPTestCase):
         self.assertEqual(res.code, httpstatus.BAD_REQUEST)
         self.assertEqual(res.headers["Content-Type"], 'application/json')
         self.assertEqual(escape.json_decode(res.body), {
-            "type": "BadRepresentation",
+            "type": "BadRequest",
             "message": "unprocessable",
             "foo": "bar",
         })
@@ -353,7 +353,7 @@ class TestREST(AsyncHTTPTestCase):
         self.assertEqual(res.code, httpstatus.BAD_REQUEST)
         self.assertEqual(res.headers["Content-Type"], 'application/json')
         self.assertEqual(escape.json_decode(res.body), {
-            "type": "BadRepresentation",
+            "type": "BadRequest",
             "message": "unprocessable",
             "foo": "bar",
         })
@@ -365,7 +365,7 @@ class TestREST(AsyncHTTPTestCase):
         self.assertEqual(res.code, httpstatus.BAD_REQUEST)
         self.assertEqual(res.headers["Content-Type"], 'application/json')
         self.assertEqual(escape.json_decode(res.body), {
-            "type": "BadRepresentation",
+            "type": "BadRequest",
             "message": "unprocessable",
             "foo": "bar",
         })
@@ -378,7 +378,7 @@ class TestREST(AsyncHTTPTestCase):
         self.assertEqual(res.code, httpstatus.BAD_REQUEST)
         self.assertEqual(res.headers["Content-Type"], 'application/json')
         self.assertEqual(escape.json_decode(res.body), {
-            "type": "BadRepresentation",
+            "type": "BadRequest",
             "message": "unprocessable",
             "foo": "bar",
         })

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,2 @@
 [flake8]
-exclude = build/*,venv*/*,doc/source/conf.py
+exclude = build/*,venv/*,doc/source/conf.py


### PR DESCRIPTION
Reverts simphony/tornado-webapi#19

This is because I didn't pin the simphony-remote version, so this would break the current master there.
I am going to release a 0.2.0 and move on from there.
