### PR TITLE
Forces the resource identifier as a string

### DIFF
--- a/tornadowebapi/handler.py
+++ b/tornadowebapi/handler.py
@@ -102,7 +102,7 @@ class CollectionHandler(BaseHandler):
 
         self.set_status(httpstatus.OK)
         # Need to convert into a dict for security issue tornado/1009
-        self.write({"items": list(items)})
+        self.write({"items": [str(item) for item in items]})
         self.flush()
 
     @gen.coroutine
@@ -134,7 +134,7 @@ class CollectionHandler(BaseHandler):
             raise web.HTTPError(httpstatus.INTERNAL_SERVER_ERROR)
 
         location = with_end_slash(
-            url_path_join(self.request.full_url(), resource_id))
+            url_path_join(self.request.full_url(), str(resource_id)))
 
         self.set_status(httpstatus.CREATED)
         self.set_header("Location", location)

--- a/tornadowebapi/tests/test_webapi.py
+++ b/tornadowebapi/tests/test_webapi.py
@@ -26,8 +26,8 @@ class Student(Resource):
 
     @gen.coroutine
     def create(self, representation):
-        id = str(type(self).id)
-        self.collection[id] = representation
+        id = type(self).id
+        self.collection[str(id)] = representation
         type(self).id += 1
         return id
 
@@ -138,7 +138,7 @@ class TestREST(AsyncHTTPTestCase):
         res = self.fetch("/api/v1/students/")
         self.assertEqual(res.code, httpstatus.OK)
         self.assertEqual(escape.json_decode(res.body),
-                         {"items": [1, 2, 3]})
+                         {"items": ["1", "2", "3"]})
 
     def test_create(self):
         res = self.fetch(


### PR DESCRIPTION
Fixes #25 so that identifiers are always strings.
