### PR TITLE
Validate representation returning representation.

### DIFF
--- a/tornadowebapi/resource.py
+++ b/tornadowebapi/resource.py
@@ -183,18 +183,27 @@ class Resource:
         """
         return []
 
-    def validate(self, representation):
-        """Validates the representation incoming from a request.
+    def validate_representation(self, representation):
+        """Validates the representation incoming from a request,
+        after it has been decoded.
         Any exception occurring in this method will be converted into
         a BadRepresentation exception.
 
         This method is always called before being dispatched to the CRUD
         methods accepting a representation. By default, it does nothing,
-        and accepts any representation.
+        accepts any representation, and returns the same representation.
+
+        The method can also be used to modify the incoming representation
+        so that it's compliant with the expectations, or return a new
+        representation.
+
+        Returns
+        -------
+        The representation that will be used.
 
         Raises
         ------
         BadRepresentation:
             If the resource collection does not support the method.
         """
-        pass
+        return representation

--- a/tornadowebapi/tests/resources.py
+++ b/tornadowebapi/tests/resources.py
@@ -5,7 +5,7 @@ from tornadowebapi import exceptions
 from tornadowebapi.resource import Resource
 
 
-class Student(Resource):
+class WorkingResource(Resource):
 
     collection = OrderedDict()
     id = 0
@@ -41,6 +41,10 @@ class Student(Resource):
     @gen.coroutine
     def items(self):
         return list(self.collection.keys())
+
+
+class Student(WorkingResource):
+    pass
 
 
 class Teacher(Resource):
@@ -93,9 +97,20 @@ class Broken(Resource):
     items = boom
 
 
-class Validated(Resource):
-    def validate(self, representation):
+class ExceptionValidated(Resource):
+    def validate_representation(self, representation):
         raise Exception("woo!")
+
+
+class NullReturningValidated(Resource):
+    def validate_representation(self, representation):
+        pass
+
+
+class CorrectValidated(WorkingResource):
+    def validate_representation(self, representation):
+        representation["hello"] = 5
+        return representation
 
 
 class AlreadyPresent(Resource):


### PR DESCRIPTION
Use method `validate_representation` instead of `validate`, and requires it to return the representation.
This is a backward incompatible change, and client code depending on 0.4 will need to upgrade.
