### PR TITLE
Let our exceptions bubble out from validation routines, instead of converting them

### DIFF
--- a/tornadowebapi/handler.py
+++ b/tornadowebapi/handler.py
@@ -140,6 +140,8 @@ class CollectionHandler(BaseHandler):
         try:
             decoded_rep = escape.json_decode(self.request.body)
             representation = res_handler.validate_representation(decoded_rep)
+        except exceptions.WebAPIException:
+            raise
         except Exception:
             self.log.exception("invalid payload received.")
             raise web.HTTPError(httpstatus.BAD_REQUEST)
@@ -186,6 +188,8 @@ class ResourceHandler(BaseHandler):
 
         try:
             identifier = res_handler.validate_identifier(identifier)
+        except exceptions.WebAPIException:
+            raise
         except Exception:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 
@@ -217,6 +221,8 @@ class ResourceHandler(BaseHandler):
 
         try:
             identifier = res_handler.validate_identifier(identifier)
+        except exceptions.WebAPIException:
+            raise
         except Exception:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 
@@ -248,6 +254,8 @@ class ResourceHandler(BaseHandler):
         try:
             decoded = escape.json_decode(self.request.body)
             representation = res_handler.validate_representation(decoded)
+        except exceptions.WebAPIException:
+            raise
         except Exception:
             raise web.HTTPError(httpstatus.BAD_REQUEST)
 
@@ -257,6 +265,8 @@ class ResourceHandler(BaseHandler):
 
         try:
             identifier = res_handler.validate_identifier(identifier)
+        except exceptions.WebAPIException:
+            raise
         except Exception:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 
@@ -285,6 +295,8 @@ class ResourceHandler(BaseHandler):
 
         try:
             identifier = res_handler.validate_identifier(identifier)
+        except exceptions.WebAPIException:
+            raise
         except Exception:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 

--- a/tornadowebapi/handler.py
+++ b/tornadowebapi/handler.py
@@ -140,8 +140,8 @@ class CollectionHandler(BaseHandler):
         try:
             decoded_rep = escape.json_decode(self.request.body)
             representation = res_handler.validate_representation(decoded_rep)
-        except exceptions.WebAPIException:
-            raise
+        except exceptions.WebAPIException as e:
+            raise self.to_http_exception(e)
         except Exception:
             self.log.exception("invalid payload received.")
             raise web.HTTPError(httpstatus.BAD_REQUEST)
@@ -188,8 +188,8 @@ class ResourceHandler(BaseHandler):
 
         try:
             identifier = res_handler.validate_identifier(identifier)
-        except exceptions.WebAPIException:
-            raise
+        except exceptions.WebAPIException as e:
+            raise self.to_http_exception(e)
         except Exception:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 
@@ -221,8 +221,8 @@ class ResourceHandler(BaseHandler):
 
         try:
             identifier = res_handler.validate_identifier(identifier)
-        except exceptions.WebAPIException:
-            raise
+        except exceptions.WebAPIException as e:
+            raise self.to_http_exception(e)
         except Exception:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 
@@ -254,8 +254,8 @@ class ResourceHandler(BaseHandler):
         try:
             decoded = escape.json_decode(self.request.body)
             representation = res_handler.validate_representation(decoded)
-        except exceptions.WebAPIException:
-            raise
+        except exceptions.WebAPIException as e:
+            raise self.to_http_exception(e)
         except Exception:
             raise web.HTTPError(httpstatus.BAD_REQUEST)
 
@@ -265,8 +265,8 @@ class ResourceHandler(BaseHandler):
 
         try:
             identifier = res_handler.validate_identifier(identifier)
-        except exceptions.WebAPIException:
-            raise
+        except exceptions.WebAPIException as e:
+            raise self.to_http_exception(e)
         except Exception:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 
@@ -295,8 +295,8 @@ class ResourceHandler(BaseHandler):
 
         try:
             identifier = res_handler.validate_identifier(identifier)
-        except exceptions.WebAPIException:
-            raise
+        except exceptions.WebAPIException as e:
+            raise self.to_http_exception(e)
         except Exception:
             raise web.HTTPError(httpstatus.NOT_FOUND)
 

--- a/tornadowebapi/resource.py
+++ b/tornadowebapi/resource.py
@@ -186,8 +186,10 @@ class Resource:
     def validate_representation(self, representation):
         """Validates the representation incoming from a request,
         after it has been decoded.
-        Any exception occurring in this method will be converted into
-        a BadRepresentation exception.
+        Any generic exception occurring in this method will be
+        converted into a BadRepresentation exception.
+        Exceptions that belong to this distribution will be let through to
+        produce the expected response.
 
         This method is always called before being dispatched to the CRUD
         methods accepting a representation. By default, it does nothing,
@@ -207,6 +209,8 @@ class Resource:
         """Validates the identifier from a request.
         Any exception occurring in this method will be converted into
         a NotFound exception.
+        Exceptions that belong to this distribution will be let through to
+        produce the expected response.
 
         Note: We use NotFound (404) because the URL is likely valid.
         If our identifiers are all integers, so that

--- a/tornadowebapi/tests/resources.py
+++ b/tornadowebapi/tests/resources.py
@@ -102,6 +102,11 @@ class ExceptionValidated(Resource):
         raise Exception("woo!")
 
 
+class OurExceptionValidated(Resource):
+    def validate_representation(self, representation):
+        raise exceptions.BadRepresentation("woo!")
+
+
 class NullReturningValidated(Resource):
     def validate_representation(self, representation):
         pass
@@ -122,6 +127,11 @@ class AlreadyPresent(Resource):
 class InvalidIdentifier(Resource):
     def validate_identifier(self, identifier):
         raise Exception("woo!")
+
+
+class OurExceptionInvalidIdentifier(Resource):
+    def validate_identifier(self, identifier):
+        raise exceptions.BadRepresentation("woo!")
 
 
 class Sheep(Resource):

--- a/tornadowebapi/tests/test_webapi.py
+++ b/tornadowebapi/tests/test_webapi.py
@@ -187,7 +187,7 @@ class TestWebAPI(AsyncHTTPTestCase):
 
     def test_unexistent_resource_type(self):
         res = self.fetch(
-            "/api/v1/teachers/",
+            "/api/v1/notpresent/",
             method="POST",
             body=escape.json_encode({
                 "foo": "bar"
@@ -197,7 +197,7 @@ class TestWebAPI(AsyncHTTPTestCase):
         self.assertEqual(res.code, httpstatus.NOT_FOUND)
 
         res = self.fetch(
-            "/api/v1/teachers/",
+            "/api/v1/notpresent/",
             method="GET",
         )
 


### PR DESCRIPTION
We want to leave WebAPI exceptions untouched if they are raised within the validators.
