### PR TITLE
Fixes tornado behavior. Removes flush.

### DIFF
--- a/tornadowebapi/web_handlers.py
+++ b/tornadowebapi/web_handlers.py
@@ -202,7 +202,6 @@ class BaseWebHandler(web.RequestHandler):
         if entity is None:
             self.clear_header('Content-Type')
             self.set_status(httpstatus.NO_CONTENT)
-            self.flush()
             return
 
         self.set_status(httpstatus.OK)


### PR DESCRIPTION
Apparently, flush() in this case removes Content-Length. Not calling flush leaves
Content-Length to zero in the headers. This for some reason, is reason enough for not
adding Transfer-Encoding to chunked in HTTP1Connection, something that is not accepted
because a 204 response must not have a body, hence no Transfer-Encoding.