### PR TITLE
Renamed ResourceHandler to ModelConnector

### DIFF
--- a/doc/source/api/tornadowebapi.deserializers.rst
+++ b/doc/source/api/tornadowebapi.deserializers.rst
@@ -1,0 +1,30 @@
+tornadowebapi.deserializers package
+===================================
+
+Submodules
+----------
+
+tornadowebapi.deserializers.base_deserializer module
+----------------------------------------------------
+
+.. automodule:: tornadowebapi.deserializers.base_deserializer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.deserializers.basic_rest_deserializer module
+----------------------------------------------------------
+
+.. automodule:: tornadowebapi.deserializers.basic_rest_deserializer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tornadowebapi.deserializers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/tornadowebapi.parsers.rst
+++ b/doc/source/api/tornadowebapi.parsers.rst
@@ -1,0 +1,30 @@
+tornadowebapi.parsers package
+=============================
+
+Submodules
+----------
+
+tornadowebapi.parsers.base_parser module
+----------------------------------------
+
+.. automodule:: tornadowebapi.parsers.base_parser
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.parsers.json_parser module
+----------------------------------------
+
+.. automodule:: tornadowebapi.parsers.json_parser
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tornadowebapi.parsers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/tornadowebapi.renderers.rst
+++ b/doc/source/api/tornadowebapi.renderers.rst
@@ -1,0 +1,30 @@
+tornadowebapi.renderers package
+===============================
+
+Submodules
+----------
+
+tornadowebapi.renderers.base_renderer module
+--------------------------------------------
+
+.. automodule:: tornadowebapi.renderers.base_renderer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.renderers.json_renderer module
+--------------------------------------------
+
+.. automodule:: tornadowebapi.renderers.json_renderer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tornadowebapi.renderers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/tornadowebapi.rst
+++ b/doc/source/api/tornadowebapi.rst
@@ -6,7 +6,12 @@ Subpackages
 
 .. toctree::
 
+    tornadowebapi.deserializers
     tornadowebapi.http
+    tornadowebapi.parsers
+    tornadowebapi.renderers
+    tornadowebapi.serializers
+    tornadowebapi.transports
 
 Submodules
 ----------
@@ -19,10 +24,42 @@ tornadowebapi.authenticator module
     :undoc-members:
     :show-inheritance:
 
+tornadowebapi.base_resource module
+----------------------------------
+
+.. automodule:: tornadowebapi.base_resource
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 tornadowebapi.exceptions module
 -------------------------------
 
 .. automodule:: tornadowebapi.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.filtering module
+------------------------------
+
+.. automodule:: tornadowebapi.filtering
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.items_response module
+-----------------------------------
+
+.. automodule:: tornadowebapi.items_response
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.model_connector module
+------------------------------------
+
+.. automodule:: tornadowebapi.model_connector
     :members:
     :undoc-members:
     :show-inheritance:
@@ -35,10 +72,34 @@ tornadowebapi.registry module
     :undoc-members:
     :show-inheritance:
 
-tornadowebapi.resource_handler module
--------------------------------------
+tornadowebapi.resource module
+-----------------------------
 
-.. automodule:: tornadowebapi.resource_handler
+.. automodule:: tornadowebapi.resource
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.resource_fragment module
+--------------------------------------
+
+.. automodule:: tornadowebapi.resource_fragment
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.singleton_resource module
+---------------------------------------
+
+.. automodule:: tornadowebapi.singleton_resource
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.traitlets module
+------------------------------
+
+.. automodule:: tornadowebapi.traitlets
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/api/tornadowebapi.serializers.rst
+++ b/doc/source/api/tornadowebapi.serializers.rst
@@ -1,0 +1,30 @@
+tornadowebapi.serializers package
+=================================
+
+Submodules
+----------
+
+tornadowebapi.serializers.base_serializer module
+------------------------------------------------
+
+.. automodule:: tornadowebapi.serializers.base_serializer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.serializers.basic_rest_serializer module
+------------------------------------------------------
+
+.. automodule:: tornadowebapi.serializers.basic_rest_serializer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tornadowebapi.serializers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/tornadowebapi.transports.rst
+++ b/doc/source/api/tornadowebapi.transports.rst
@@ -1,0 +1,30 @@
+tornadowebapi.transports package
+================================
+
+Submodules
+----------
+
+tornadowebapi.transports.base_transport module
+----------------------------------------------
+
+.. automodule:: tornadowebapi.transports.base_transport
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+tornadowebapi.transports.basic_rest_transport module
+----------------------------------------------------
+
+.. automodule:: tornadowebapi.transports.basic_rest_transport
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: tornadowebapi.transports
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/jstests/application.py
+++ b/jstests/application.py
@@ -3,15 +3,15 @@ from tornado import web
 import tornado.ioloop
 
 from tornadowebapi.registry import Registry
-from tornadowebapi.tests.resource_handlers import StudentHandler
-from tornadowebapi.tests.resource_handlers import ServerInfoHandler
+from tornadowebapi.tests.resource_handlers import StudentModelConn
+from tornadowebapi.tests.resource_handlers import ServerInfoModelConn
 
 
 class Application(web.Application):
     def __init__(self):
         self.reg = Registry()
-        self.reg.register(StudentHandler)
-        self.reg.register(ServerInfoHandler)
+        self.reg.register(StudentModelConn)
+        self.reg.register(ServerInfoModelConn)
         handlers = self.reg.api_handlers('/')
         base_path = os.path.dirname(os.path.abspath(__file__))
         handlers += [('/(.*)', web.StaticFileHandler, {'path': base_path})]

--- a/tornadowebapi/model_connector.py
+++ b/tornadowebapi/model_connector.py
@@ -5,13 +5,13 @@ from tornadowebapi.singleton_resource import SingletonResource
 from . import exceptions
 
 
-class ResourceHandler:
-    """Base class for resource handlers.
-    To implement a new ResourceHandler class, inherit from this subclass
+class ModelConnector:
+    """Base class for data layers.
+    To implement a new DataLayer class, inherit from this subclass
     and reimplement the CRUD class methods with the appropriate
     logic. Additionally, specify a resource_class of type Resource.
 
-    The ResourceHandler exports two member vars: application and current_user.
+    The DataLayer exports two member vars: application and current_user.
     They are equivalent to the members in the tornado web handler.
     """
 

--- a/tornadowebapi/model_connector.py
+++ b/tornadowebapi/model_connector.py
@@ -6,12 +6,12 @@ from . import exceptions
 
 
 class ModelConnector:
-    """Base class for data layers.
-    To implement a new DataLayer class, inherit from this subclass
+    """Base class for model connectors.
+    To implement a new ModelConnector class, inherit from this subclass
     and reimplement the CRUD class methods with the appropriate
     logic. Additionally, specify a resource_class of type Resource.
 
-    The DataLayer exports two member vars: application and current_user.
+    The ModelConnector exports two member vars: application and current_user.
     They are equivalent to the members in the tornado web handler.
     """
 

--- a/tornadowebapi/registry.py
+++ b/tornadowebapi/registry.py
@@ -5,7 +5,7 @@ from .web_handlers import (
 
 from .transports import BasicRESTTransport
 from .utils import url_path_join, with_end_slash
-from .resource_handler import ResourceHandler
+from .model_connector import ModelConnector
 from .authenticator import NullAuthenticator
 
 
@@ -46,8 +46,8 @@ class Registry:
     def registered_handlers(self):
         return self._registered_handlers
 
-    def register(self, handler):
-        """Registers a ResourceHandler.
+    def register(self, model_connector):
+        """Registers a DataLayer.
         The associated resource will be used to determine the URL
         representing the resource collections. For example, a resource Image
         will have URLs of the type
@@ -56,18 +56,19 @@ class Registry:
 
         Parameters
         ----------
-        handler: ResourceHandler
-            A subclass of the ResourceHandler
+        model_connector: ModelConnector
+            A subclass of the ModelConnector
 
         Raises
         ------
         TypeError:
             if typ is not a subclass of Resource
         """
-        if handler is None or not issubclass(handler, ResourceHandler):
-            raise TypeError("handler must be a subclass of ResourceHandler")
+        if model_connector is None or not issubclass(model_connector,
+                                                     ModelConnector):
+            raise TypeError("handler must be a subclass of ModelConnector")
 
-        name = handler.bound_name()
+        name = model_connector.bound_name()
 
         if name in self._registered_handlers:
             raise ValueError(
@@ -75,10 +76,10 @@ class Registry:
                 "class {}, so it cannot be used by class {}".format(
                     name,
                     self._registered_handlers[name].__name__,
-                    handler.__name__
+                    model_connector.__name__
                 ))
 
-        self._registered_handlers[name] = handler
+        self._registered_handlers[name] = model_connector
 
     def __getitem__(self, collection_name):
         """Returns the class from the collection name with the

--- a/tornadowebapi/registry.py
+++ b/tornadowebapi/registry.py
@@ -47,7 +47,7 @@ class Registry:
         return self._registered_handlers
 
     def register(self, model_connector):
-        """Registers a DataLayer.
+        """Registers a Model Connector.
         The associated resource will be used to determine the URL
         representing the resource collections. For example, a resource Image
         will have URLs of the type

--- a/tornadowebapi/resource.py
+++ b/tornadowebapi/resource.py
@@ -116,10 +116,11 @@ def mandatory_absents(resource, scope):
 
 
 def is_valid(resource, scope):
-    """Returns True if the resource is valid, False otherwise.
+    """
+    Returns True if the resource is valid, False otherwise.
     Validity is defined as follows:
-        - identifier is not None
-        - mandatory_absents is empty
+    - identifier is not None
+    - mandatory_absents is empty
     """
     return (resource.identifier is not None and
             len(mandatory_absents(resource, scope)) == 0)

--- a/tornadowebapi/serializers/base_serializer.py
+++ b/tornadowebapi/serializers/base_serializer.py
@@ -7,7 +7,7 @@ from tornadowebapi.items_response import ItemsResponse
 
 class BaseSerializer(metaclass=abc.ABCMeta):
     """The serializer is in charge of converting the data
-    from the ResourceHandler into a dictionary with appropriate
+    from the DataLayer into a dictionary with appropriate
     keys.
 
     This dictionary will then be passed to the renderer to be

--- a/tornadowebapi/singleton_resource.py
+++ b/tornadowebapi/singleton_resource.py
@@ -9,7 +9,7 @@ class SingletonResource(BaseResource):
     - There is only one resource
     - There is no concept of collection, nor of collection name
     - The resource has a name, which is the one that will end up in
-      the url
+    the url
     - The resource has no id.
 
     The URL will appear as
@@ -17,7 +17,6 @@ class SingletonResource(BaseResource):
     /name/
 
     Regular Resource documentation applies for the definition.
-
     """
     @classmethod
     def name(cls):

--- a/tornadowebapi/singleton_resource.py
+++ b/tornadowebapi/singleton_resource.py
@@ -2,14 +2,15 @@ from tornadowebapi.base_resource import BaseResource
 
 
 class SingletonResource(BaseResource):
-    """A model representing a singleton resource in our system, that is
+    """
+    A model representing a singleton resource in our system, that is
     a resource that exists only as a single entity.
     As a result, the behavior is different from a collection-based resource:
-        - There is only one resource
-        - There is no concept of collection, nor of collection name
-        - The resource has a name, which is the one that will end up in
-          the url
-        - The resource has no id.
+    - There is only one resource
+    - There is no concept of collection, nor of collection name
+    - The resource has a name, which is the one that will end up in
+      the url
+    - The resource has no id.
 
     The URL will appear as
 
@@ -20,7 +21,8 @@ class SingletonResource(BaseResource):
     """
     @classmethod
     def name(cls):
-        """Identifies the name of the resource.
+        """
+        Identifies the name of the resource.
         The default is the name of the class, lowercase.
 
         Override this method to return a different name.

--- a/tornadowebapi/tests/resource_handlers.py
+++ b/tornadowebapi/tests/resource_handlers.py
@@ -3,13 +3,13 @@ from collections import OrderedDict
 from tornado import gen
 from tornadowebapi import exceptions
 from tornadowebapi.resource_fragment import ResourceFragment
-from tornadowebapi.resource_handler import ResourceHandler
+from tornadowebapi.model_connector import ModelConnector
 from tornadowebapi.resource import Resource
 from tornadowebapi.singleton_resource import SingletonResource
 from tornadowebapi.traitlets import Unicode, Int, List, OneOf
 
 
-class WorkingResourceHandler(ResourceHandler):
+class WorkingModelConn(ModelConnector):
     """Base class for tests. Still missing the resource_class
     that must be set in the derived class."""
 
@@ -71,7 +71,7 @@ class WorkingResourceHandler(ResourceHandler):
                            total=len(self.collection.values()))
 
 
-class SingletonResourceHandler(ResourceHandler):
+class SingletonModelConn(ModelConnector):
     instance = {}
 
     @gen.coroutine
@@ -108,7 +108,7 @@ class Student(Resource):
     age = Int()
 
 
-class StudentHandler(WorkingResourceHandler):
+class StudentModelConn(WorkingModelConn):
     resource_class = Student
 
 
@@ -118,7 +118,7 @@ class Teacher(Resource):
     discipline = List()
 
 
-class TeacherHandler(ResourceHandler):
+class TeacherModelConn(ModelConnector):
     resource_class = Teacher
 
 
@@ -132,7 +132,7 @@ class City(Resource):
     mayor = OneOf(Person)
 
 
-class CityHandler(WorkingResourceHandler):
+class CityModelConn(WorkingModelConn):
     resource_class = City
 
 
@@ -141,7 +141,7 @@ class ServerInfo(SingletonResource):
     status = Unicode()
 
 
-class ServerInfoHandler(SingletonResourceHandler):
+class ServerInfoModelConn(SingletonModelConn):
     resource_class = ServerInfo
 
 
@@ -149,7 +149,7 @@ class UnsupportAll(Resource):
     pass
 
 
-class UnsupportAllHandler(ResourceHandler):
+class UnsupportAllModelConn(ModelConnector):
     resource_class = UnsupportAll
 
 
@@ -157,7 +157,7 @@ class Unprocessable(Resource):
     pass
 
 
-class UnprocessableHandler(ResourceHandler):
+class UnprocessableModelConn(ModelConnector):
     resource_class = Unprocessable
 
     @gen.coroutine
@@ -181,7 +181,7 @@ class UnsupportsCollection(Resource):
     pass
 
 
-class UnsupportsCollectionHandler(ResourceHandler):
+class UnsupportsCollectionModelConn(ModelConnector):
     resource_class = UnsupportsCollection
 
     @gen.coroutine
@@ -193,7 +193,7 @@ class Broken(Resource):
     pass
 
 
-class BrokenHandler(ResourceHandler):
+class BrokenModelConn(ModelConnector):
     resource_class = Broken
 
     @gen.coroutine
@@ -211,7 +211,7 @@ class ExceptionValidated(Resource):
     pass
 
 
-class ExceptionValidatedHandler(ResourceHandler):
+class ExceptionValidatedModelConn(ModelConnector):
     resource_class = ExceptionValidated
 
     def preprocess_representation(self, representation):
@@ -222,7 +222,7 @@ class OurExceptionValidated(Resource):
     pass
 
 
-class OurExceptionValidatedHandler(ResourceHandler):
+class OurExceptionValidatedModelConn(ModelConnector):
     resource_class = OurExceptionValidated
 
     def preprocess_representation(self, representation):
@@ -233,7 +233,7 @@ class NullReturningValidated(Resource):
     pass
 
 
-class NullReturningValidatedHandler(ResourceHandler):
+class NullReturningValidatedModelConn(ModelConnector):
     resource_class = NullReturningValidated
 
     def preprocess_representation(self, representation):
@@ -244,7 +244,7 @@ class CorrectValidated(Resource):
     pass
 
 
-class CorrectValidatedHandler(WorkingResourceHandler):
+class CorrectValidatedModelConn(WorkingModelConn):
     resource_class = CorrectValidated
 
     def preprocess_representation(self, representation):
@@ -256,7 +256,7 @@ class AlreadyPresent(Resource):
     pass
 
 
-class AlreadyPresentHandler(ResourceHandler):
+class AlreadyPresentModelConn(ModelConnector):
     resource_class = AlreadyPresent
 
     @gen.coroutine
@@ -268,7 +268,7 @@ class InvalidIdentifier(Resource):
     pass
 
 
-class InvalidIdentifierHandler(ResourceHandler):
+class InvalidIdentifierModelConn(ModelConnector):
     resource_class = InvalidIdentifier
 
     def preprocess_identifier(self, identifier):
@@ -279,7 +279,7 @@ class OurExceptionInvalidIdentifier(Resource):
     pass
 
 
-class OurExceptionInvalidIdentifierHandler(ResourceHandler):
+class OurExceptionInvalidIdentifierModelConn(ModelConnector):
     resource_class = OurExceptionInvalidIdentifier
 
     def preprocess_identifier(self, identifier):
@@ -292,7 +292,7 @@ class Sheep(Resource):
         return "sheep"
 
 
-class SheepHandler(ResourceHandler):
+class SheepModelConn(ModelConnector):
     """Sheep plural is the same as singular."""
     resource_class = Sheep
 
@@ -303,7 +303,7 @@ class Octopus(Resource):
         return "octopi"
 
 
-class OctopusHandler(ResourceHandler):
+class OctopusModelConn(ModelConnector):
     """Octopus plural is a matter of debate."""
     resource_class = Octopus
 
@@ -312,10 +312,10 @@ class Frobnicator(Resource):
     pass
 
 
-class FrobnicatorHandler(ResourceHandler):
+class FrobnicatorModelConn(ModelConnector):
     """A weird name to test if it's kept"""
     resource_class = Frobnicator
 
 
-class WrongClassHandler(ResourceHandler):
+class WrongClassModelConn(ModelConnector):
     resource_class = str

--- a/tornadowebapi/tests/test_data_layer.py
+++ b/tornadowebapi/tests/test_data_layer.py
@@ -1,15 +1,15 @@
 from unittest.mock import Mock
 
 from tornado.testing import AsyncTestCase, gen_test
-from tornadowebapi.resource_handler import ResourceHandler
-from tornadowebapi.tests.resource_handlers import ServerInfoHandler, \
-    TeacherHandler
+from tornadowebapi.model_connector import ModelConnector
+from tornadowebapi.tests.resource_handlers import ServerInfoModelConn, \
+    TeacherModelConn
 
 
-class TestResourceHandler(AsyncTestCase):
+class TestModelConn(AsyncTestCase):
     @gen_test
     def test_basic_expectations(self):
-        handler = ResourceHandler(Mock(), Mock())
+        handler = ModelConnector(Mock(), Mock())
         with self.assertRaises(NotImplementedError):
             yield handler.create(Mock())
 
@@ -26,18 +26,18 @@ class TestResourceHandler(AsyncTestCase):
             yield handler.items(Mock())
 
     def test_bound_name(self):
-        handler = ResourceHandler(Mock(), Mock())
+        handler = ModelConnector(Mock(), Mock())
 
         with self.assertRaises(TypeError):
-            ResourceHandler.bound_name()
+            ModelConnector.bound_name()
 
         handler.resource_class = str
         with self.assertRaises(TypeError):
-            ResourceHandler.bound_name()
+            ModelConnector.bound_name()
 
-        self.assertEqual(ServerInfoHandler.bound_name(), "serverinfo")
-        self.assertEqual(TeacherHandler.bound_name(), "teachers")
+        self.assertEqual(ServerInfoModelConn.bound_name(), "serverinfo")
+        self.assertEqual(TeacherModelConn.bound_name(), "teachers")
 
     def test_handle_singleton(self):
-        self.assertTrue(ServerInfoHandler.handles_singleton())
-        self.assertFalse(TeacherHandler.handles_singleton())
+        self.assertTrue(ServerInfoModelConn.handles_singleton())
+        self.assertFalse(TeacherModelConn.handles_singleton())

--- a/tornadowebapi/tests/test_jsapi.py
+++ b/tornadowebapi/tests/test_jsapi.py
@@ -4,7 +4,7 @@ from unittest import mock
 from tornadowebapi.http import httpstatus
 from tornadowebapi.registry import Registry
 from tornadowebapi.tests.resource_handlers import (
-    StudentHandler, TeacherHandler, FrobnicatorHandler)
+     StudentModelConn, TeacherModelConn, FrobnicatorModelConn)
 from tornadowebapi.tests.utils import AsyncHTTPTestCase
 from tornado import web
 
@@ -12,14 +12,14 @@ from tornado import web
 class TestJSAPIHandler(AsyncHTTPTestCase):
     def setUp(self):
         super().setUp()
-        StudentHandler.collection = OrderedDict()
-        StudentHandler.id = 0
+        StudentModelConn.collection = OrderedDict()
+        StudentModelConn.id = 0
 
     def get_app(self):
         registry = Registry()
-        registry.register(StudentHandler)
-        registry.register(TeacherHandler)
-        registry.register(FrobnicatorHandler)
+        registry.register(StudentModelConn)
+        registry.register(TeacherModelConn)
+        registry.register(FrobnicatorModelConn)
         handlers = registry.api_handlers('/')
         app = web.Application(handlers=handlers)
         app.hub = mock.Mock()

--- a/tornadowebapi/tests/test_registry.py
+++ b/tornadowebapi/tests/test_registry.py
@@ -3,8 +3,8 @@ from unittest import mock
 
 from tornadowebapi.registry import Registry
 from tornadowebapi.tests.resource_handlers import (
-    StudentHandler, SheepHandler, OctopusHandler, FrobnicatorHandler,
-    WrongClassHandler)
+    StudentModelConn, SheepModelConn, OctopusModelConn, FrobnicatorModelConn,
+    WrongClassModelConn)
 from tornadowebapi.transports.base_transport import BaseTransport
 
 
@@ -13,28 +13,28 @@ class TestRegistry(unittest.TestCase):
         reg = Registry()
 
         # Register the classes.
-        reg.register(StudentHandler)
-        reg.register(SheepHandler)
-        reg.register(OctopusHandler)
-        reg.register(FrobnicatorHandler)
+        reg.register(StudentModelConn)
+        reg.register(SheepModelConn)
+        reg.register(OctopusModelConn)
+        reg.register(FrobnicatorModelConn)
 
         # Check if they are there with the appropriate form
         self.assertIn("students", reg)
         self.assertIn("sheep", reg)
         self.assertIn("octopi", reg)
-        self.assertEqual(reg["students"], StudentHandler)
-        self.assertEqual(reg["sheep"], SheepHandler)
-        self.assertEqual(reg["octopi"], OctopusHandler)
+        self.assertEqual(reg["students"], StudentModelConn)
+        self.assertEqual(reg["sheep"], SheepModelConn)
+        self.assertEqual(reg["octopi"], OctopusModelConn)
 
         self.assertIn("frobnicators", reg)
-        self.assertEqual(reg["frobnicators"], FrobnicatorHandler)
+        self.assertEqual(reg["frobnicators"], FrobnicatorModelConn)
 
     def test_double_registration(self):
         reg = Registry()
 
-        reg.register(StudentHandler)
+        reg.register(StudentModelConn)
         with self.assertRaises(ValueError):
-            reg.register(StudentHandler)
+            reg.register(StudentModelConn)
 
     def test_incorrect_class_registration(self):
         reg = Registry()
@@ -46,7 +46,7 @@ class TestRegistry(unittest.TestCase):
             reg.register(int)
 
         with self.assertRaises(TypeError):
-            reg.register(WrongClassHandler)
+            reg.register(WrongClassModelConn)
 
     def test_authenticator(self):
         reg = Registry()

--- a/tornadowebapi/tests/test_webapi.py
+++ b/tornadowebapi/tests/test_webapi.py
@@ -14,30 +14,30 @@ from tornadowebapi.tests.utils import AsyncHTTPTestCase
 from tornado import web, escape
 
 ALL_RESOURCES = (
-    resource_handlers.AlreadyPresentHandler,
-    resource_handlers.ExceptionValidatedHandler,
-    resource_handlers.NullReturningValidatedHandler,
-    resource_handlers.CorrectValidatedHandler,
-    resource_handlers.OurExceptionValidatedHandler,
-    resource_handlers.BrokenHandler,
-    resource_handlers.UnsupportsCollectionHandler,
-    resource_handlers.UnprocessableHandler,
-    resource_handlers.UnsupportAllHandler,
-    resource_handlers.StudentHandler,
-    resource_handlers.TeacherHandler,
-    resource_handlers.InvalidIdentifierHandler,
-    resource_handlers.OurExceptionInvalidIdentifierHandler,
-    resource_handlers.ServerInfoHandler,
+    resource_handlers.AlreadyPresentModelConn,
+    resource_handlers.ExceptionValidatedModelConn,
+    resource_handlers.NullReturningValidatedModelConn,
+    resource_handlers.CorrectValidatedModelConn,
+    resource_handlers.OurExceptionValidatedModelConn,
+    resource_handlers.BrokenModelConn,
+    resource_handlers.UnsupportsCollectionModelConn,
+    resource_handlers.UnprocessableModelConn,
+    resource_handlers.UnsupportAllModelConn,
+    resource_handlers.StudentModelConn,
+    resource_handlers.TeacherModelConn,
+    resource_handlers.InvalidIdentifierModelConn,
+    resource_handlers.OurExceptionInvalidIdentifierModelConn,
+    resource_handlers.ServerInfoModelConn,
 )
 
 
 class TestWebAPI(AsyncHTTPTestCase, LogTrapTestCase):
     def setUp(self):
         super().setUp()
-        resource_handlers.StudentHandler.collection = OrderedDict()
-        resource_handlers.StudentHandler.id = 0
-        resource_handlers.ServerInfoHandler.instance = {}
-        resource_handlers.StudentHandler.id = 0
+        resource_handlers.StudentModelConn.collection = OrderedDict()
+        resource_handlers.StudentModelConn.id = 0
+        resource_handlers.ServerInfoModelConn.instance = {}
+        resource_handlers.StudentModelConn.id = 0
 
     def get_app(self):
         registry = Registry()
@@ -60,7 +60,7 @@ class TestWebAPI(AsyncHTTPTestCase, LogTrapTestCase):
                              "identifiers": []
                          })
 
-        handler = resource_handlers.StudentHandler
+        handler = resource_handlers.StudentModelConn
         handler.collection[1] = handler.resource_class(
             identifier="1",
             name="john wick",
@@ -130,7 +130,7 @@ class TestWebAPI(AsyncHTTPTestCase, LogTrapTestCase):
                              "identifiers": []
                          })
 
-        handler = resource_handlers.StudentHandler
+        handler = resource_handlers.StudentModelConn
         handler.collection[1] = handler.resource_class(
             identifier="1",
             name="john wick",
@@ -218,7 +218,7 @@ class TestWebAPI(AsyncHTTPTestCase, LogTrapTestCase):
                           "identifiers": []
                           })
 
-        handler = resource_handlers.StudentHandler
+        handler = resource_handlers.StudentModelConn
         handler.collection[1] = handler.resource_class(
             identifier="1",
             name="john wick",
@@ -338,7 +338,7 @@ class TestWebAPI(AsyncHTTPTestCase, LogTrapTestCase):
         self.assertEqual(res.code, httpstatus.NOT_FOUND)
         self.assertNotIn("Content-Type", res.headers)
 
-        handler = resource_handlers.StudentHandler
+        handler = resource_handlers.StudentModelConn
         handler.collection["0"].age = Absent
 
         # Verify output checks


### PR DESCRIPTION
Renamed the ResourceHandler class to

1. free the term ResourceHandler that will be used later.
2. express clearly that the entity is supposed to connect the model object with the rest of the framework
