### PR TITLE
Change model connector API - names

### DIFF
--- a/tornadowebapi/model_connector.py
+++ b/tornadowebapi/model_connector.py
@@ -58,7 +58,7 @@ class ModelConnector:
         raise NotImplementedError()
 
     @gen.coroutine
-    def get_object(self, instance, **kwargs):
+    def retrieve_object(self, instance, **kwargs):
         """Called to retrieve a specific resource given its
         identifier. Correspond to a GET operation on the resource URL.
 
@@ -168,8 +168,8 @@ class ModelConnector:
         raise NotImplementedError()
 
     @gen.coroutine
-    def get_collection(self, items_response, offset=None, limit=None,
-                       **kwargs):
+    def retrieve_collection(
+            self, items_response, offset=None, limit=None, **kwargs):
         """Invoked when a request is performed to the collection
         URL. Passes an empty items_response object that must be filled
         with the relevant information.

--- a/tornadowebapi/model_connector.py
+++ b/tornadowebapi/model_connector.py
@@ -1,7 +1,5 @@
 from tornado import gen, log
 
-from . import exceptions
-
 
 class ModelConnector:
     """Base class for model connectors.
@@ -28,7 +26,7 @@ class ModelConnector:
         self.log = log.app_log
 
     @gen.coroutine
-    def create(self, instance, **kwargs):
+    def create_object(self, instance, **kwargs):
         """Called to create a resource with the given data.
         The member is passed with an instance of Resource, pre-filled
         with the data from the passed (and decoded) payload.
@@ -60,7 +58,7 @@ class ModelConnector:
         raise NotImplementedError()
 
     @gen.coroutine
-    def retrieve(self, instance, **kwargs):
+    def get_object(self, instance, **kwargs):
         """Called to retrieve a specific resource given its
         identifier. Correspond to a GET operation on the resource URL.
 
@@ -92,7 +90,7 @@ class ModelConnector:
         raise NotImplementedError()
 
     @gen.coroutine
-    def update(self, instance, **kwargs):
+    def replace_object(self, instance, **kwargs):
         """Called to update (fully) a specific Resource given its
         identifier with new data. Correspond to a PUT operation on the
         Resource URL.
@@ -118,7 +116,33 @@ class ModelConnector:
         raise NotImplementedError()
 
     @gen.coroutine
-    def delete(self, instance, **kwargs):
+    def update_object(self, instance, **kwargs):
+        """Called to update (fully) a specific Resource given its
+        identifier with new data. Correspond to a PUT operation on the
+        Resource URL.
+
+        Parameters
+        ----------
+        instance:
+            An instance of the resource_class. This instance will be filled
+            with data from the payload.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        NotFound:
+            Raised if the resource with the given identifier cannot
+            be found
+        NotImplementedError:
+            If the resource does not support the method.
+        """
+        raise NotImplementedError()
+
+    @gen.coroutine
+    def delete_object(self, instance, **kwargs):
         """Called to delete a specific resource given its identifier.
         Corresponds to a DELETE operation on the resource URL.
 
@@ -144,28 +168,8 @@ class ModelConnector:
         raise NotImplementedError()
 
     @gen.coroutine
-    def exists(self, instance, **kwargs):
-        """Returns True if the resource with a given identifier
-        exists. False otherwise.
-
-        Parameters
-        ----------
-        instance: Schema
-            A Resource instance. Only the identifier will be filled.
-
-        Returns
-        -------
-        bool: True if found, False otherwise.
-        """
-        try:
-            yield self.retrieve(instance)
-        except exceptions.NotFound:
-            return False
-
-        return True
-
-    @gen.coroutine
-    def items(self, items_response, offset=None, limit=None, **kwargs):
+    def get_collection(self, items_response, offset=None, limit=None,
+                       **kwargs):
         """Invoked when a request is performed to the collection
         URL. Passes an empty items_response object that must be filled
         with the relevant information.

--- a/tornadowebapi/tests/resource_handlers.py
+++ b/tornadowebapi/tests/resource_handlers.py
@@ -19,14 +19,14 @@ class WorkingModelConn(ModelConnector):
     id = 0
 
     @gen.coroutine
-    def create(self, instance, **kwargs):
+    def create_object(self, instance, **kwargs):
         id = type(self).id
         self.collection[str(id)] = instance
         instance.identifier = str(id)
         type(self).id += 1
 
     @gen.coroutine
-    def retrieve(self, instance, **kwargs):
+    def retrieve_object(self, instance, **kwargs):
         if instance.identifier not in self.collection:
             raise exceptions.NotFound()
 
@@ -35,22 +35,23 @@ class WorkingModelConn(ModelConnector):
             setattr(instance, trait_name, getattr(stored_item, trait_name))
 
     @gen.coroutine
-    def update(self, instance, **kwargs):
+    def replace_object(self, instance, **kwargs):
         if instance.identifier not in self.collection:
             raise exceptions.NotFound()
 
         self.collection[instance.identifier] = instance
 
     @gen.coroutine
-    def delete(self, instance, **kwargs):
+    def delete_object(self, instance, **kwargs):
         if instance.identifier not in self.collection:
             raise exceptions.NotFound()
 
         del self.collection[instance.identifier]
 
     @gen.coroutine
-    def items(self, items_response,
-              offset=None, limit=None, filter_=None, **kwargs):
+    def retrieve_collection(
+            self, items_response,
+            offset=None, limit=None, filter_=None, **kwargs):
         if offset is None:
             offset = 0
 
@@ -77,11 +78,11 @@ class SingletonModelConn(ModelConnector):
     instance = {}
 
     @gen.coroutine
-    def create(self, instance, **kwargs):
+    def create_object(self, instance, **kwargs):
         self.instance['instance'] = instance
 
     @gen.coroutine
-    def retrieve(self, instance, **kwargs):
+    def retrieve_object(self, instance, **kwargs):
         if "instance" not in self.instance:
             raise exceptions.NotFound()
 
@@ -91,14 +92,14 @@ class SingletonModelConn(ModelConnector):
                             trait_name))
 
     @gen.coroutine
-    def update(self, instance, **kwargs):
+    def replace_object(self, instance, **kwargs):
         if "instance" not in self.instance:
             raise exceptions.NotFound()
 
         self.instance["instance"] = instance
 
     @gen.coroutine
-    def delete(self, instance, **kwargs):
+    def delete_object(self, instance, **kwargs):
         if "instance" not in self.instance:
             raise exceptions.NotFound()
 
@@ -201,19 +202,20 @@ class Unprocessable(Schema):
 
 class UnprocessableModelConn(ModelConnector):
     @gen.coroutine
-    def create(self, instance, **kwargs):
+    def create_object(self, instance, **kwargs):
         raise exceptions.BadRepresentation("unprocessable", foo="bar")
 
     @gen.coroutine
-    def update(self, instance, **kwargs):
+    def replace_object(self, instance, **kwargs):
         raise exceptions.BadRepresentation("unprocessable", foo="bar")
 
     @gen.coroutine
-    def retrieve(self, instance, **kwargs):
+    def retrieve_object(self, instance, **kwargs):
         raise exceptions.BadRepresentation("unprocessable", foo="bar")
 
     @gen.coroutine
-    def items(self, items_response, offset=None, limit=None, **kwargs):
+    def retrieve_collection(
+            self, items_response, offset=None, limit=None, **kwargs):
         raise exceptions.BadRepresentation("unprocessable", foo="bar")
 
 
@@ -252,11 +254,11 @@ class BrokenModelConn(ModelConnector):
     def boom(self, *args):
         raise Exception("Boom!")
 
-    create = boom
-    retrieve = boom
-    update = boom
-    delete = boom
-    items = boom
+    create_object = boom
+    retrieve_object = boom
+    replace_object = boom
+    delete_object = boom
+    retrieve_collection = boom
 
 
 class BrokenDetails(ResourceDetails):

--- a/tornadowebapi/tests/resource_handlers.py
+++ b/tornadowebapi/tests/resource_handlers.py
@@ -356,7 +356,7 @@ class AlreadyPresent(Schema):
 class AlreadyPresentModelConn(ModelConnector):
 
     @gen.coroutine
-    def create(self, *args, **kwargs):
+    def create_object(self, *args, **kwargs):
         raise exceptions.Exists()
 
 

--- a/tornadowebapi/tests/test_data_layer.py
+++ b/tornadowebapi/tests/test_data_layer.py
@@ -9,16 +9,16 @@ class TestModelConn(AsyncTestCase):
     def test_basic_expectations(self):
         handler = ModelConnector(Mock(), Mock())
         with self.assertRaises(NotImplementedError):
-            yield handler.create(Mock())
+            yield handler.create_object(Mock())
 
         with self.assertRaises(NotImplementedError):
-            yield handler.retrieve(Mock())
+            yield handler.retrieve_object(Mock())
 
         with self.assertRaises(NotImplementedError):
-            yield handler.update(Mock())
+            yield handler.replace_object(Mock())
 
         with self.assertRaises(NotImplementedError):
-            yield handler.delete(Mock())
+            yield handler.delete_object(Mock())
 
         with self.assertRaises(NotImplementedError):
-            yield handler.items(Mock())
+            yield handler.retrieve_collection(Mock())

--- a/tornadowebapi/web_handlers.py
+++ b/tornadowebapi/web_handlers.py
@@ -107,7 +107,7 @@ class ResourceDetails(Resource):
 
             self._check_none(identifier, "identifier", "preprocess_identifier")
 
-            yield connector.get_object(resource, **args)
+            yield connector.retrieve_object(resource, **args)
 
             self._check_resource_sanity(resource, "output")
 
@@ -137,7 +137,7 @@ class ResourceDetails(Resource):
                 identifier)
 
         try:
-            yield connector.get_object(resource, **args)
+            yield connector.retrieve_object(resource, **args)
         except NotFound:
             raise web.HTTPError(httpstatus.NOT_FOUND)
         else:
@@ -272,7 +272,7 @@ class ResourceSingletonDetails(Resource):
             self._check_resource_sanity(resource, "input")
 
             try:
-                yield connector.get_object(resource)
+                yield connector.retrieve_object(resource)
             except NotFound:
                 yield connector.create_object(resource, **args)
             else:

--- a/tornadowebapi/web_handlers.py
+++ b/tornadowebapi/web_handlers.py
@@ -1,5 +1,6 @@
 from tornado import gen, web
 from tornado.web import HTTPError
+from tornadowebapi.exceptions import NotFound
 from tornadowebapi.resource import Resource
 from tornadowebapi.traitlets import TraitError
 from . import exceptions
@@ -18,7 +19,7 @@ class ResourceList(Resource):
         items_response = ItemsResponse(self.schema)
 
         with self.exceptions_to_http(connector, "get"):
-            yield connector.items(items_response, **args)
+            yield connector.get_collection(items_response, **args)
 
         for resource in items_response.items:
             self._check_none(resource.identifier,
@@ -64,7 +65,7 @@ class ResourceList(Resource):
 
             self._check_resource_sanity(resource, "input")
 
-            yield connector.create(resource, **args)
+            yield connector.create_object(resource, **args)
 
             self._check_none(resource.identifier,
                              "resource_id",
@@ -106,7 +107,7 @@ class ResourceDetails(Resource):
 
             self._check_none(identifier, "identifier", "preprocess_identifier")
 
-            yield connector.retrieve(resource, **args)
+            yield connector.get_object(resource, **args)
 
             self._check_resource_sanity(resource, "output")
 
@@ -135,12 +136,12 @@ class ResourceDetails(Resource):
                 self.schema,
                 identifier)
 
-            exists = yield connector.exists(resource, **args)
-
-        if exists:
-            raise web.HTTPError(httpstatus.CONFLICT)
-        else:
+        try:
+            yield connector.get_object(resource, **args)
+        except NotFound:
             raise web.HTTPError(httpstatus.NOT_FOUND)
+        else:
+            raise web.HTTPError(httpstatus.CONFLICT)
 
     @gen.coroutine
     def put(self, identifier):
@@ -183,7 +184,7 @@ class ResourceDetails(Resource):
                                      identifier):
             self._check_resource_sanity(resource, "input")
 
-            yield connector.update(resource, **args)
+            yield connector.replace_object(resource, **args)
 
         self._send_to_client(None)
 
@@ -211,7 +212,7 @@ class ResourceDetails(Resource):
                 self.schema,
                 identifier)
 
-            yield connector.delete(resource, **args)
+            yield connector.delete_object(resource, **args)
 
         self._send_to_client(None)
 
@@ -228,7 +229,7 @@ class ResourceSingletonDetails(Resource):
             resource = transport.deserializer.deserialize(
                 self.schema)
 
-            yield connector.retrieve(resource, **args)
+            yield connector.retrieve_object(resource, **args)
 
             self._check_resource_sanity(resource, "output")
 
@@ -270,12 +271,12 @@ class ResourceSingletonDetails(Resource):
 
             self._check_resource_sanity(resource, "input")
 
-            exists = yield connector.exists(resource)
-
-            if exists:
+            try:
+                yield connector.get_object(resource)
+            except NotFound:
+                yield connector.create_object(resource, **args)
+            else:
                 raise exceptions.Exists()
-
-            yield connector.create(resource, **args)
 
         self._send_created_to_client(resource)
 
@@ -307,7 +308,7 @@ class ResourceSingletonDetails(Resource):
         with self.exceptions_to_http(connector, "put"):
             self._check_resource_sanity(resource, "input")
 
-            yield connector.update(resource, **args)
+            yield connector.replace_object(resource, **args)
 
         self._send_to_client(None)
 
@@ -322,6 +323,6 @@ class ResourceSingletonDetails(Resource):
             resource = transport.deserializer.deserialize(
                 self.schema)
 
-            yield connector.delete(resource, **args)
+            yield connector.delete_object(resource, **args)
 
         self._send_to_client(None)

--- a/tornadowebapi/web_handlers.py
+++ b/tornadowebapi/web_handlers.py
@@ -19,7 +19,7 @@ class ResourceList(Resource):
         items_response = ItemsResponse(self.schema)
 
         with self.exceptions_to_http(connector, "get"):
-            yield connector.get_collection(items_response, **args)
+            yield connector.retrieve_collection(items_response, **args)
 
         for resource in items_response.items:
             self._check_none(resource.identifier,
@@ -136,12 +136,13 @@ class ResourceDetails(Resource):
                 self.schema,
                 identifier)
 
-        try:
-            yield connector.retrieve_object(resource, **args)
-        except NotFound:
-            raise web.HTTPError(httpstatus.NOT_FOUND)
-        else:
-            raise web.HTTPError(httpstatus.CONFLICT)
+        with self.exceptions_to_http("post", str(connector), identifier):
+            try:
+                yield connector.retrieve_object(resource, **args)
+            except NotFound:
+                raise web.HTTPError(httpstatus.NOT_FOUND)
+            else:
+                raise web.HTTPError(httpstatus.CONFLICT)
 
     @gen.coroutine
     def put(self, identifier):


### PR DESCRIPTION
We adapt the API of our model connector to the same API in flask-rest-jsonapi data layer.
create/retrieve/update/delete are now c/r/u/d_object.
Different from flask-rest-jsonapi, we use:

- retrieve instead of get
- replace instead of update (replace = PUT operation, update = PATCH operation) 